### PR TITLE
Rename collection fields for consistency

### DIFF
--- a/app/models/graph/types/query.rb
+++ b/app/models/graph/types/query.rb
@@ -4,39 +4,39 @@ module Graph
       name "Query"
       description "The query root of this schema"
 
-      # Relay
-      field :node, GraphQL::Relay::Node.field
-      field :nodes, GraphQL::Relay::Node.plural_field
-
       field :person, Graph.find_by_id_field(Graph::Types::Person, ::Person)
-      field :people, types[Graph::Types::Person] do
+      field :allPeople, !types[!Person] do
         resolve ->(_, _, _) { ::Person.all }
       end
 
       field :planet, Graph.find_by_id_field(Graph::Types::Planet, ::Planet)
-      field :planets, types[Graph::Types::Planet] do
+      field :allPlanets, !types[!Planet] do
         resolve ->(_, _, _) { ::Planet.all }
       end
 
       field :film, Graph.find_by_id_field(Graph::Types::Film, ::Film)
-      field :films, types[Graph::Types::Film] do
+      field :allFilms, !types[!Film] do
         resolve ->(_, _, _) { ::Film.all }
       end
 
       field :species, Graph.find_by_id_field(Graph::Types::Species, ::Species)
-      field :allSpecies, types[Graph::Types::Species] do
+      field :allSpecies, !types[!Species] do
         resolve ->(_, _, _) { ::Species.all }
       end
 
       field :starship, Graph.find_by_id_field(Graph::Types::Starship, ::Starship)
-      field :starships, types[Graph::Types::Starship] do
+      field :allStarships, !types[!Starship] do
         resolve ->(_, _, _) { ::Starship.all }
       end
 
       field :vehicle, Graph.find_by_id_field(Graph::Types::Vehicle, ::Vehicle)
-      field :vehicles, types[Graph::Types::Vehicle] do
+      field :allVehicles, !types[!Vehicle] do
         resolve ->(_, _, _) { ::Vehicle.all }
       end
+
+      # Relay
+      field :node, GraphQL::Relay::Node.field
+      field :nodes, GraphQL::Relay::Node.plural_field
     end
   end
 end


### PR DESCRIPTION
We have `species` and `allSpecies` because `species` is both singular and plural.

For consistency, I've renamed the other fields to `all*`.

cc @xuorig 